### PR TITLE
fix public assistant storage policy

### DIFF
--- a/supabase/migrations/20240220203835_fix_storage_policy.sql
+++ b/supabase/migrations/20240220203835_fix_storage_policy.sql
@@ -1,0 +1,11 @@
+CREATE OR REPLACE FUNCTION public.non_private_assistant_exists(p_name text)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+AS $$
+    SELECT EXISTS (
+        SELECT 1
+        FROM assistants
+        WHERE (id::text = (storage.foldername(p_name)[2])) AND sharing <> 'private'
+    );
+$$;


### PR DESCRIPTION
The original `non_private_assistant_exists` was incorrect since it checked filename, not foldername agianst assistant id. Assistant image file path is `<user-id>/<assistant-id>/<file-id>`. storage.filename would return file-id not assistant-id and the check would fail in the id::text clause.