### PR TITLE
Bugfix/anthropic errors

### DIFF
--- a/app/api/chat/anthropic/route.ts
+++ b/app/api/chat/anthropic/route.ts
@@ -45,25 +45,32 @@ export async function POST(request: NextRequest) {
         const stream = AnthropicStream(response)
         return new StreamingTextResponse(stream)
       } catch (error: any) {
-        console.error("Error parsing Anthropic API response:", error)
+        const errorCode = error.status || 500
+        console.error("Error parsing Anthropic API response:", error, {
+          payload: json
+        })
         return new NextResponse(
           JSON.stringify({
             message:
               "An error occurred while parsing the Anthropic API response"
           }),
-          { status: 500 }
+          { status: errorCode }
         )
       }
     } catch (error: any) {
-      console.error("Error calling Anthropic API:", error)
+      const errorCode = error.status || 500
+      console.error("Error calling Anthropic API:", error, {
+        payload: json
+      })
       return new NextResponse(
         JSON.stringify({
           message: "An error occurred while calling the Anthropic API"
         }),
-        { status: 500 }
+        { status: errorCode }
       )
     }
   } catch (error: any) {
+    console.error("Error processing request:", error, { payload: json })
     let errorMessage = error.message || "An unexpected error occurred"
     const errorCode = error.status || 500
     if (errorMessage.toLowerCase().includes("api key not found")) {


### PR DESCRIPTION
fix 

```
Error calling Anthropic API: Error: 400 {"type":"error","error":{…
…"type":"invalid_request_error","message":"messages: all messages must have non-empty content except for the optional final assistant message"}}

    at (node_modules/@anthropic-ai/sdk/error.mjs:36:0)
    at (node_modules/@anthropic-ai/sdk/core.mjs:256:23)
    at (node_modules/@anthropic-ai/sdk/core.mjs:299:0)
    at (app/api/chat/anthropic/route.ts:34:23)
    at (node_modules/next/dist/esm/server/future/route-modules/app-route/module.js:189:0)
    at (node_modules/next/dist/esm/server/future/route-modules/app-route/module.js:128:0)
    at (node_modules/next/dist/esm/server/future/route-modules/app-route/module.js:251:0)
    at (node_modules/next/dist/esm/server/web/edge-route-module-wrapper.js:81:0)
    at (node_modules/next/dist/esm/server/web/adapter.js?8c03:157:0) {
  status: 400,
  headers: {
  connection: 'keep-alive',
  content-length: '168',
  content-type: 'application/json',
  date: 'Wed, 20 Mar 2024 15:26:40 GMT',
  request-id: 'req_017HvmhQ9PLR6wNUzCThDAm2',
  via: '1.1 google',
  x-cloud-trace-context: 'a8a82d7649cdbabe100dab1d9b75ef7f',
  x-should-retry: 'false'
},
  error: {
  type: 'error',
  error: {
  type: 'invalid_request_error',
  message: 'messages: all messages must have non-empty content except for the optional final assistant message'
}
}
}
```